### PR TITLE
fix sand conservation

### DIFF
--- a/Assets/OcsTerrain/Scripts/Excavation/Sand/SandManager.cs
+++ b/Assets/OcsTerrain/Scripts/Excavation/Sand/SandManager.cs
@@ -112,8 +112,9 @@ public class SandManager : MonoBehaviour
             if (!_sand[i].isActivated) continue;
             if (_sand[i].rb.transform.position.y < _minAltitude)
             {
-                _sand[i].rb.velocity = Vector3.zero;
+                _deformableTerrain.AddOffset(_sand[i].sandScript._radius/(_deformableTerrain.terrainHeightmapResolution*_deformableTerrain.terrainHeightmapResolution));
                 Dispose(i);
+                terrainUpdate = true;
                 continue;
             }
             if (_sand[i].rb.IsSleeping() && _sand[i].sandScript._onTerrain)
@@ -125,7 +126,7 @@ public class SandManager : MonoBehaviour
                 {
                     if(hit.collider.tag == "Terrain")
                     {
-                        _deformableTerrain.SetHeight(_sand[i].rb.transform.position, _sand[i].rb.transform.position.y);
+                        _deformableTerrain.SetHeight(_sand[i].rb.transform.position, _sand[i].rb.transform.position.y + _sand[i].sandScript._radius);
                         Dispose(i);
                         terrainUpdate = true;
                     }

--- a/Assets/OcsTerrain/Scripts/Excavation/Terrain/DeformableTerrain.cs
+++ b/Assets/OcsTerrain/Scripts/Excavation/Terrain/DeformableTerrain.cs
@@ -25,6 +25,7 @@ public class DeformableTerrain : MonoBehaviour
     [SerializeField] private Vector3 _dimensionRatio;
 
     [SerializeField] private int _terrainHeightmapResolution;
+    public int terrainHeightmapResolution { get => this._terrainHeightmapResolution; }
 
     [SerializeField] private bool _isHeightmapChanged;
 
@@ -157,6 +158,17 @@ public class DeformableTerrain : MonoBehaviour
             for (int j = -1; j < 2; j++)
                 if (IsValidIndex(z + i, x + j))
                     _heightmap[z + i, x + j] = h;
+    }
+
+    public void AddOffset(float value)
+    {
+        for(int i = 0; i < _terrainHeightmapResolution; i++)
+        {
+            for(int j = 0; j < _terrainHeightmapResolution; j++)
+            {
+                _heightmap[i, j] += value / _terrainSize.y;
+            }
+        }
     }
 
     private IEnumerator UpdateTerrainCoroutine()


### PR DESCRIPTION
## 地形内の土砂の量が保存されるようにスクリプトを微修正

* 砂粒が堆積する際に発生するTerrainの高さの変更量を、掘削する際の式と同じものに変更

* 地形の下に潜って落下した砂粒の分、Terrainの高さが変化するように修正
砂粒が落下した位置のみに高さを還元してしまうと、掘削時に発生する体積によって重機が跳ね飛ばされるため